### PR TITLE
fix(package): pack all template files into the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+!template/**


### PR DESCRIPTION
npm ignores some files by default if you don't specify otherwise in a .npmignore file. This commit
adds one that explicitly states that npm should pack everything in the template directory.

fixes #2